### PR TITLE
OAuth2 Bearer token policy

### DIFF
--- a/Snippets/Add Azure AD OAuth2 bearer token to request to AD protected API.xml
+++ b/Snippets/Add Azure AD OAuth2 bearer token to request to AD protected API.xml
@@ -1,0 +1,35 @@
+<!-- This snippet allows you to obtain a OAuth2 bearer token from Azure AD and add it to a request to an AD-protected API (App) -->
+<!-- Copy this snippet into the inbound processing section -->
+<policies>
+	<inbound>
+		<!-- Send request to Azure AD to obtain a bearer token -->
+		<!-- Parameters: authorizationServer - format https://login.windows.net/TENANT-GUID/oauth2/token -->
+		<!-- Parameters: scope - The scope for the AD App, should be URI encoded -->
+		<!-- Parameters: clientId - The id of the AD App -->
+		<!-- Parameters: clientSecret - The secret of the AD App, should be URI encoded -->
+		<send-request ignore-error="true" timeout="20" response-variable-name="bearerToken" mode="new">
+			<set-url>{{authorizationServer}}</set-url>
+			<set-method>POST</set-method>
+			<set-header name="Content-Type" exists-action="override">
+				<value>application/x-www-form-urlencoded</value>
+			</set-header>
+			<set-body>   
+				@{
+					return "client_id={{clientId}}&resource={{scope}}&client_secret={{clientSecret}}&grant_type=client_credentials";
+				}
+			</set-body>
+		</send-request>
+		<set-header name="Authorization" exists-action="override">
+			<value>
+				@("Bearer " + (String)((IResponse)context.Variables["bearerToken"]).Body.As<JObject>()["access_token"])
+			</value>
+		</set-header>
+		<base/>
+	</inbound>
+	<backend>
+		<base/>
+	</backend>
+	<outbound>
+		<base/>
+	</outbound>
+</policies>	

--- a/Snippets/Add Azure AD OAuth2 bearer token to request to AD protected API.xml
+++ b/Snippets/Add Azure AD OAuth2 bearer token to request to AD protected API.xml
@@ -24,6 +24,8 @@
 				@("Bearer " + (String)((IResponse)context.Variables["bearerToken"]).Body.As<JObject>()["access_token"])
 			</value>
 		</set-header>
+		<!--  We do not want to expose our APIM subscription key to the backend API  -->
+        	<set-header exists-action="delete" name="Ocp-Apim-Subscription-Key"/>
 		<base/>
 	</inbound>
 	<backend>


### PR DESCRIPTION
The policy allows to add an OAuth2 bearer token to a request to an AD-protected API (App). An AD application is needed in order to use the policy.