### PR TITLE
Updated typo (Azure docs #11453)

### DIFF
--- a/examples/Simple Google OAuth validate-jwt.policy.xml
+++ b/examples/Simple Google OAuth validate-jwt.policy.xml
@@ -8,7 +8,7 @@
     <!-- Note the clock-skew attribute. This attribute is required to prevent some intermittent errors and can be tailored to suit your scenario. -->
     <validate-jwt header-name="Authorization" failed-validation-httpcode="401" clock-skew="120" failed-validation-error-message="Unauthorized. Access token is missing or invalid.">
       <openid-config url="https://accounts.google.com/.well-known/openid-configuration" />
-      <!-- Without the following section, only https://accouonts.google.com is allowed. However the .net google client library often returns an issue related to accounts.google.com -->
+      <!-- Without the following section, only https://accounts.google.com is allowed. However the .net google client library often returns an issue related to accounts.google.com -->
       <!-- Having both issuers ensures all usage scenarios work. -->
       <issuers>
         <issuer>accounts.google.com</issuer>


### PR DESCRIPTION
Fixes MicrosoftDocs/azure-docs#11453

https://accouonts.google.com is allowed

Changed to:

https://accounts.google.com is allowed