### PR TITLE
Fix condition in the when policy

### DIFF
--- a/examples/Look up Key Vault certificate using Managed Service Identity and call backend.policy.xml
+++ b/examples/Look up Key Vault certificate using Managed Service Identity and call backend.policy.xml
@@ -20,7 +20,7 @@
         <cache-lookup-value key="mycert" variable-name="keyVaultCertBase64" />
         <!-- call Key Vault if secret is not found in the cache -->
         <choose>
-            <when condition="@(!context.Variables.ContainsKey("keyVaultCertResponse"))">
+            <when condition="@(!context.Variables.ContainsKey("keyVaultCertBase64"))">
                 <send-request mode="new" response-variable-name="keyVaultCertResponse" timeout="20" ignore-error="false">
                     <set-url>https://msikvtest.vault.azure.net/secrets/mycert/?api-version=2016-10-01</set-url>
                     <set-method>GET</set-method>


### PR DESCRIPTION
The policy expression in the `when` policy should be checking for the response from the cache lookup and skip fetching the cert from key vault every time.

The current expression resolves to `true` always.