### PR TITLE
Fix response variable name variable

### DIFF
--- a/examples/Backend OAuth2 Authentication With Cache.policy.xml
+++ b/examples/Backend OAuth2 Authentication With Cache.policy.xml
@@ -16,7 +16,7 @@
         <cache-lookup-value key="@("bearerToken")" variable-name="bearerToken" />
         <choose>
             <when condition="@(!context.Variables.ContainsKey("bearerToken"))">
-                <send-request ignore-error="true" timeout="20" response-variable-name="accessToken" mode="new">
+                <send-request ignore-error="true" timeout="20" response-variable-name="accessTokenResult" mode="new">
                     <set-url>{{authorizationServer}}</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Content-Type" exists-action="override">


### PR DESCRIPTION
The attribute "response-variable-name" was originally set to "accessToken" which makes the policy on line 29 break because it references a variable called "accessTokenResult" which doesn't exist. To fix that, I updated the "response-variable-name" to "accessTokenResult" on line 7.