### PR TITLE
example: Switch from basic authentication to cookie based authentication

### DIFF
--- a/examples/Switch from basic authentication to cookie based authentication after initial request.xml
+++ b/examples/Switch from basic authentication to cookie based authentication after initial request.xml
@@ -1,0 +1,34 @@
+<policies>
+    <inbound>
+        <base />
+        <set-backend-service base-url="{{MYBACKEND_URL}}" />
+        <cache-lookup-value key="BACKEND-COOKIE" default-value="" variable-name="backendCookie" />
+        <choose>
+            <when condition="@(context.Request.Method == "GET" && context.Variables.GetValueOrDefault<string>("backendCookie","") != "")">
+                <set-header name="Cookie" exists-action="override">
+                    <value>@(context.Variables.GetValueOrDefault<string>("backendCookie",""))</value>
+                </set-header>
+            </when>
+            <otherwise>
+                <authentication-basic username="{{MYBACKEND_USER}}" password="{{MYBACKEND_PASSWORD}}" />
+            </otherwise>
+        </choose>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode > 399)">
+                <cache-remove-value key="BACKEND-COOKIE" />
+            </when>
+            <when condition="@(context.Variables.GetValueOrDefault<string>("backendCookie","") == "")">
+                <cache-store-value key="BACKEND-COOKIE" value="@(context.Response.Headers.GetValueOrDefault("Set-Cookie",""))" duration="3600" />
+            </when>
+        </choose>
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
An API level policy for a e.g. JAVA Spring based backend where after an initial request with basic authentication all subsequent requests are cookie based.

Shows application of custom cache value handling.