### PR TITLE
Edit comment in Filter on IP Address when using Application Gateway.policy.xml

### DIFF
--- a/examples/Filter on IP Address when using Application Gateway.policy.xml
+++ b/examples/Filter on IP Address when using Application Gateway.policy.xml
@@ -3,7 +3,7 @@
     is accessed from an Application Gateway.  The Application Gateway will write the original request
     IP to the "X-Forwarded-For" header.  The set-header policy evaluates this IP address against a list of
     IP ranges (if any).  If a match is found, a value is written to the X-Forwarded-For header and the
-    following check-header policy will validate the match.  If no match is found 
+    following check-header policy will validate the match. 
 -->
 <policies>
 	<inbound>


### PR DESCRIPTION
Removing extra text in comment. 
Fixes https://github.com/MicrosoftDocs/azure-docs/issues/91509