### PR TITLE
Update Mask async calls as synchronous.policy.xml

### DIFF
--- a/examples/Mask async calls as synchronous.policy.xml
+++ b/examples/Mask async calls as synchronous.policy.xml
@@ -3,6 +3,8 @@
 
 <!-- API used for this example is an Azure Logic Apps (request/resposne), in which retruns HTTP 202 status code, -->
 <!-- and location header to retrieve the terminal payload. Retry count and interval is fixed  in this example but can also be customized. -->
+<!-- This is not for long running requests.  Request taking 4+ minutes can experience forced timeounts in a cloud environment where devices such as a load balancer
+have hard coded connection timeouts.  For scenarios running more than seconds, make sure the client is involved to keep the connection alive.  -->
 
 <policies>
     <inbound>


### PR DESCRIPTION
This is not for long running requests.  Request taking 4+ minutes can experience forced timeounts in a cloud environment where devices such as a load balancer have hard coded connection timeouts.  For scenarios running more than seconds, make sure the client is involved to keep the connection alive.