### PR TITLE
Fixed bug in the validate-azure-ad-token policy invocation

### DIFF
--- a/examples/oauth-proxy/oauth-proxy-validate-token-fragment.xml
+++ b/examples/oauth-proxy/oauth-proxy-validate-token-fragment.xml
@@ -3,7 +3,7 @@
     <!-- IdP provider specific validation of the access-tokens returned by the IdP -->
     <validate-azure-ad-token 
         tenant-id="{{TenantId}}"
-        token-value="@((string)context.Variables["refreshToken"])">
+        token-value="@((string)context.Variables["accessToken"])">
         <client-application-ids>
             <application-id>{{ClientId}}</application-id>
         </client-application-ids>


### PR DESCRIPTION
Not sure how this one slipped through, but I was using the wrong token in the same Entra policy check.